### PR TITLE
build: update package version and improve Android build script

### DIFF
--- a/buildAndroid.sh
+++ b/buildAndroid.sh
@@ -1,1 +1,15 @@
-pnpm exec expo prebuild && cd android && ./gradlew assembleRelease && cd .. && ls -al android/app/build/outputs/apk/release/app-release.apk && mv android/app/build/outputs/apk/release/app-release.apk ~/temp/writer.apk
+# Clean any existing prebuild artifacts
+rm -rf android ios
+
+# Install dependencies to ensure expo-modules-core is available
+pnpm install --frozen-lockfile
+
+# Run prebuild with clean slate
+pnpm exec expo prebuild --clean
+
+# Build the Android APK
+cd android && ./gradlew assembleRelease && cd ..
+
+# Verify and move the APK
+ls -al android/app/build/outputs/apk/release/app-release.apk
+mv android/app/build/outputs/apk/release/app-release.apk ~/temp/writer.apk

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "writer",
-  "version": "2.1.2",
+  "version": "2.1.6",
   "main": "expo-router/entry",
   "author": "Jien Huang",
   "description": "A writer app for iOS and Android",
@@ -40,6 +40,8 @@
     "expo-keep-awake": "~14.1.4",
     "expo-linking": "7.1.7",
     "expo-local-authentication": "16.0.5",
+    "expo-modules-autolinking": "~2.1.14",
+    "expo-modules-core": "~2.5.0",
     "expo-router": "5.1.4",
     "expo-speech": "13.1.7",
     "expo-splash-screen": "0.30.10",


### PR DESCRIPTION
- Bump version from 2.1.2 to 2.1.5
- Add expo-modules-autolinking and expo-modules-core dependencies
- Refactor buildAndroid.sh to include clean steps and better organization